### PR TITLE
Fixes a small typo

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -14,7 +14,7 @@ const chalk = require('chalk')
 function main () {
   deploy()
     .then(function () {
-      console.log(chalk.green('Project successfully deployed to Githib Pages'))
+      console.log(chalk.green('Project successfully deployed to GitHub Pages'))
     })
     .catch(function (error) {
       console.error(chalk.red(error))


### PR DESCRIPTION
Just noticed 'Githib' during use and changed it to 'GitHub'.

Thanks!